### PR TITLE
Ja query fixes

### DIFF
--- a/server/controllers/dashBoardController.ts
+++ b/server/controllers/dashBoardController.ts
@@ -1,11 +1,13 @@
 import axios from 'axios';
 import { Request, Response, NextFunction } from 'express';
 import * as k8s from '@kubernetes/client-node';
+import { current } from '@reduxjs/toolkit';
 
 // Interfaces define the structure and types of the data received from the API response
 interface PromResult {
   metric: Record<string, string>;
-  value: [number, string];
+  values: [number, string][];
+  value: [number, string][];
 }
 
 interface QueryResult {
@@ -25,29 +27,38 @@ interface DashboardData {
   services: number;
 }
 
+//james added typing
+
+interface PodMetrics {
+  cpu?: [number, string][];
+  memory?: [number, string][];
+}
+
+interface Pod {
+  name: string;
+  podName: string;
+  namespace: string;
+  metrics: PodMetrics;
+}
+
 const dashboardController = {
   getClusterData: async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    
-    let { time, namespace }: { time?: string | undefined; namespace?: string | undefined} = req.query;
+    let { time, namespace }: { time?: string | undefined; namespace?: string | undefined } = req.query;
     if (!time) time = '';
-    else time = '['+time+']'
-    
+    else time = '[' + time + ']';
+
     if (!namespace) namespace = '';
-    else namespace = ',namespace ='+namespace
+    else namespace = ',namespace =' + namespace;
 
     try {
-
-
       // Retrieve CPU usage data
       const responseCpuUsage = await axios.get<QueryResponse>(
         `http://localhost:9090/api/v1/query?query=container_cpu_usage_seconds_total{container!=""${namespace}}${time}`
       );
-      
-
       // Retrieve Mem usage
       const responseMemUsage = await axios.get<QueryResponse>(
         `http://localhost:9090/api/v1/query?query=container_memory_usage_bytes{container!=""${namespace}}${time}`
-      ); 
+      );
 
       // Retrieve network transmit
       const responseTransmit = await axios.get<QueryResponse>(
@@ -59,30 +70,39 @@ const dashboardController = {
         `http://localhost:9090/api/v1/query?query=node_network_receive_bytes_total{container!=""${namespace}}${time}`
       );
 
-      const test = await axios.get<QueryResponse>(
-        `http://localhost:9090/api/v1/query?query=container_cpu_usage_seconds_total{container!=""${namespace}}${time}`
-      );
+      const formattedResponse: Pod[] = [];
+      for (let i = 0; i < responseCpuUsage.data.data.result.length; i++) {
+        
+        //intialize data
+        let cpuData: [number, string][] = [];
+        let memoryData: [number, string][] = [];
+        
+        //dealing with prometheus auto pluralizing of value property
+        if (responseCpuUsage.data.data.result[i].values) {
+          cpuData = responseCpuUsage.data.data.result[i].values;
+          memoryData = responseMemUsage.data.data.result[i].values;
+        }
+        if (responseCpuUsage.data.data.result[i].value) {
+          cpuData = responseCpuUsage.data.data.result[i].value;
+          memoryData = responseMemUsage.data.data.result[i].value;
+        }
+        
+        //creating metrics object
+        const metrics: PodMetrics = { cpu: cpuData, memory: memoryData };
 
-      test.data.data.result.map((item: PromResult) => console.log(item));
+        //creating pod objects
+        const pod: Pod = {
+          name: responseCpuUsage.data.data.result[i].metric.name,
+          podName: responseCpuUsage.data.data.result[i].metric.pod,
+          namespace: responseCpuUsage.data.data.result[i].metric.namespace,
+          metrics: metrics
+        };
 
-      // Extract data from API reqs
-      const cpuUsage = responseCpuUsage.data.data.result.map((item: PromResult) => item.value);
-      const memUsage = responseMemUsage.data.data.result.map((item: PromResult) => item.value);
-      const networkTransmitUsage = responseTransmit.data.data.result.map((item: PromResult) => item.value);
-      const networkReceiveUsage = responseReceive.data.data.result.map((item: PromResult) => item.value);
-      // Format the extracted data
-      const formattedData = {
-        cpuTimestamps: cpuUsage.map((item: any[]) => item[0]),
-        cpuValues: cpuUsage.map((item: any[]) => item[1]),
-        memTimestamps: memUsage.map((item: any[]) => item[0]),
-        memValues: memUsage.map((item: any[]) => item[1]),
-        networkTransmitTimestamps: networkTransmitUsage.map((item: any[]) => item[0]),
-        networkTransmitValues: networkTransmitUsage.map((item: any[]) => item[1]),
-        networkReceiveTimestamps: networkReceiveUsage.map((item: any[]) => item[0]),
-        networkReceiveValues: networkReceiveUsage.map((item: any[]) => item[1])
-      };
-      // Return the formattedData
-      res.locals.data = formattedData;
+        //adding pod to an array to be returned to front end 
+        formattedResponse.push(pod);
+      }
+
+      res.locals.data = formattedResponse;
 
       return next();
     } catch (err) {
@@ -130,3 +150,31 @@ const dashboardController = {
 };
 
 export default dashboardController;
+
+// // Extract data from API reqs
+// const cpuUsage = responseCpuUsage.data.data.result.map((item: PromResult) => item.value);
+// const memUsage = responseMemUsage.data.data.result.map((item: PromResult) => item.value);
+// const networkTransmitUsage = responseTransmit.data.data.result.map((item: PromResult) => item.value);
+// const networkReceiveUsage = responseReceive.data.data.result.map((item: PromResult) => item.value);
+// // Format the extracted data
+// const formattedData = {
+//   cpuTimestamps: cpuUsage.map((item: any[]) => item[0]),
+//   cpuValues: cpuUsage.map((item: any[]) => item[1]),
+//   memTimestamps: memUsage.map((item: any[]) => item[0]),
+//   memValues: memUsage.map((item: any[]) => item[1]),
+//   networkTransmitTimestamps: networkTransmitUsage.map((item: any[]) => item[0]),
+//   networkTransmitValues: networkTransmitUsage.map((item: any[]) => item[1]),
+//   networkReceiveTimestamps: networkReceiveUsage.map((item: any[]) => item[0]),
+//   networkReceiveValues: networkReceiveUsage.map((item: any[]) => item[1])
+// };
+// // Return the formattedData
+ //TESTING
+      // const test = await axios.get<QueryResponse>(
+      //   `http://localhost:9090/api/v1/query?query=container_cpu_usage_seconds_total{container!=""${namespace}}[1m]`
+      // );
+
+      // test.data.data.result.map((item: PromResult) => console.log(item));
+      // console.log(test.data.data.result)
+      // console.log(test.data.data.result[0]);
+
+      // console.log(responseCpuUsage.data.data.result[0]);


### PR DESCRIPTION
3 things 

1. Prometheus auto pluralizes the value property so in my interface I added both value and values. I can't make either of them optional but it works at present. I am worried it could break. 

2. Notice the data structure for the metrics {cpu: [[time1,value1],[time2,value2],...etc]}. I did it this way to deal with potential issues from having time stamps as keys (preserving order being the big one). We probably would have been fine either way.

3. The metrics for transmit and receive are not passed at the moment because they are exclusive to one pod and aren't really comparable with CPU and memory usage. We therefore might want to both figure out where to include transmit and receive AND maybe get another metric 
